### PR TITLE
[debian] Add dep on rustc for .bash_local

### DIFF
--- a/dotfiles.rb
+++ b/dotfiles.rb
@@ -109,7 +109,7 @@ dep '.bash_local.dotfile' do
   def name
     'debian/.bash_local'
   end
-  requires 'repo.dotfile'
+  requires 'repo.dotfile', 'rustc.rust'
   met? { dotfile_exists? '.bash_local' }
   meet { shell "ln -s #{dotfiles_dir}/#{name} ~/.bash_local" }
 end


### PR DESCRIPTION
The .bash_local file looks for rustc, which is not an explicit
dependency. Add the rustc dep.