### PR TITLE
Link curl against BoringSSL

### DIFF
--- a/all.rb
+++ b/all.rb
@@ -20,7 +20,6 @@ dep 'core software' do
       'rust',
       'shellcheck',
       'tmux',
-      'openssl',
       'curl'
     ]
   }

--- a/boringssl.rb
+++ b/boringssl.rb
@@ -1,0 +1,38 @@
+meta :boringssl do
+  def dir
+    '~/Development/boringssl'
+  end
+end
+
+dep 'source.boringssl', :version do
+  version.default!('2d98d49cf') # taken from latest chromium-stable
+  requires 'git.apt'
+  met? { dir.p.exists? }
+  meet {
+    shell "mkdir -p #{dir}"
+    cd dir do
+      shell 'git clone --depth=1 --branch=chromium-stable https://github.com/google/boringssl.git .'
+      shell "git checkout #{version}"
+    end
+  }
+end
+
+dep 'lib.boringssl', :version do
+  requires 'source.boringssl', 'make.apt', 'cmake.apt', 'g++.apt', 'go.lang'
+  met? { "#{dir}/lib/libssl.a".p.exists? && "#{dir}/lib/libcrypto.a".p.exists? }
+  before {
+    cd dir do
+      shell 'rm -rf build/ lib/ && mkdir build/ && mkdir lib/'
+    end
+  }
+  meet {
+    cd "#{dir}/build" do
+      shell 'DCMAKE_BUILD_TYPE=Release cmake ..'
+      shell 'make'
+    end
+    cd "#{dir}/lib" do
+      shell 'ln -s ../build/ssl/libssl.a'
+      shell 'ln -s ../build/crypto/libcrypto.a'
+    end
+  }
+end

--- a/curl.rb
+++ b/curl.rb
@@ -1,5 +1,5 @@
 dep 'curl', :version do
-  requires 'git.apt', 'libtoolize.apt', 'autoconf.apt', 'software-properties-common.apt', 'openssl'
+  requires 'git.apt', 'libtoolize.apt', 'autoconf.apt', 'software-properties-common.apt', 'lib.boringssl'
   version.default!('7.61.1')
   met? { shell? "curl --version | grep #{version}" }
   meet {
@@ -9,7 +9,7 @@ dep 'curl', :version do
       cd 'curl' do
         shell "git checkout curl-#{version.to_s.gsub('.', '_')}"
         shell './buildconf'
-        shell 'LDFLAGS="-Wl,-rpath,/usr/local/ssl/lib -Wl,-rpath,/usr/local/lib" ./configure --with-ssl=/usr/local/ssl'
+        shell 'LIBS=-lpthread LDFLAGS="-static" ./configure --disable-shared --enable-static --with-ssl=$HOME/Development/boringssl'
         shell 'make'
         shell 'make install', sudo: true
       end

--- a/debian_common.rb
+++ b/debian_common.rb
@@ -4,6 +4,12 @@ dep 'autoconf.apt', :version do
   meet { apt_install 'autoconf', version }
 end
 
+dep 'cmake.apt', :version do
+  version.default!('3.7.2-1')
+  met? { apt_installed? 'cmake', version }
+  meet { apt_install 'cmake', version }
+end
+
 dep 'dnsutils.apt', :version do
   version.default!('1:9.10.3.dfsg.P4-12.3+deb9u4')
   met? { apt_installed? 'dnsutils', version }
@@ -14,6 +20,12 @@ dep 'file.apt', :version do
   version.default!('1:5.30-1+deb9u2')
   met? { apt_installed? 'file', version }
   meet { apt_install 'file', version }
+end
+
+dep 'g++.apt', :version do
+  version.default!('4:6.3.0-4')
+  met? { apt_installed? 'g++', version }
+  meet { apt_install 'g++', version }
 end
 
 dep 'gcc.apt', :version do

--- a/go.rb
+++ b/go.rb
@@ -1,8 +1,12 @@
 dep 'go.lang', :version  do
-  requires 'curl', 'tar.apt', 'dotfiles'
+  requires 'tar.apt'
   version.default!('1.11.2')
   met? { shell? "go version | grep #{version}" }
   meet {
+    # There is a circular dependency between go, curl and boringssl. To break
+    # the cycle, use system curl, which we remove in the after step (below).
+    shell 'apt-get -y install curl', sudo: true
+
     tarball="go#{version}.linux-amd64.tar.gz"
     url="https://dl.google.com/go/#{tarball}"
     shell <<-HERE
@@ -11,6 +15,9 @@ dep 'go.lang', :version  do
       sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go && \
       rm #{tarball}
     HERE
+  }
+  after {
+    shell 'apt-get remove -y curl', sudo: true
   }
 end
 


### PR DESCRIPTION
Rather than using OpenSSL, use BoringSSL, which is simpler, and arguably
more secure.

Build curl to link statically.