### PR TITLE
Version updates

### DIFF
--- a/ctags.rb
+++ b/ctags.rb
@@ -1,6 +1,6 @@
 dep 'ctags', :version  do
   requires 'git.apt', 'make.apt', 'autoconf.apt', 'pkg-config.apt'
-  version.default!('836df9df')
+  version.default!('64f7d619')
   met? { in_path? "ctags >= #{version}" }
   meet {
     shell <<-HERE

--- a/rust.rb
+++ b/rust.rb
@@ -30,15 +30,15 @@ end
 
 dep 'rustc.rust', :version do
   requires 'rustup.rust'
-  version.default!('1.29.0')
+  version.default!('1.31.0')
   met? { shell? "#{rustc} --version | grep #{version}" }
   meet { shell "#{rustup} update #{version} && #{rustup} default #{version}" }
 end
 
 dep 'rustfmt.rust' do
   requires 'rustup.rust'
-  met? { shell? "#{rustup} component list | grep rustfmt-preview" }
-  meet { shell "#{rustup} component add rustfmt-preview" }
+  met? { shell? "#{rustup} component list | grep rustfmt" }
+  meet { shell "#{rustup} component add rustfmt" }
 end
 
 dep 'rust-src.rust' do
@@ -49,9 +49,9 @@ end
 
 dep 'rusty-tags.rust', :version do
   requires 'rustup.rust'
-  version.default!('3.0.0')
+  version.default!('3.2.0')
   met? { shell? "#{cargo} install --list | grep 'rusty-tags v#{version}'" }
-  meet { shell "#{cargo} install --version #{version} rusty-tags" }
+  meet { shell "#{cargo} install --force --version #{version} rusty-tags" }
 end
 
 dep 'rust' do

--- a/shellcheck.rb
+++ b/shellcheck.rb
@@ -1,6 +1,6 @@
 dep 'shellcheck', :version do
   requires 'curl', 'tar.apt'
-  version.default!('0.4.7')
+  version.default!('0.6.0')
   met? { shell? "shellcheck --version | grep #{version}" }
   meet do
     tarball="shellcheck-v#{version}.linux.x86_64.tar.xz"


### PR DESCRIPTION
Update ctags to 64f7d619.

Update rustc to 1.31.0.

Update rusty-tags to 3.2.0.

Update shellcheck to 0.6.0.