### PR TITLE
Fix certigo deps

### DIFF
--- a/certigo.rb
+++ b/certigo.rb
@@ -1,5 +1,5 @@
 dep 'source.certigo'  do
-  requires 'go.lang'
+  requires 'go'
   met? { login_shell 'go list github.com/square/certigo' }
   meet { login_shell 'go get github.com/square/certigo' }
 end


### PR DESCRIPTION
Include the go directories in the dependencies, so they are present by
the time certigo attempts to install.