### PR TITLE
Remove git dependency for curl and boringssl

### DIFF
--- a/boringssl.rb
+++ b/boringssl.rb
@@ -5,15 +5,20 @@ meta :boringssl do
 end
 
 dep 'source.boringssl', :version do
-  version.default!('2d98d49cf') # taken from latest chromium-stable
-  requires 'personal:git'
+  version.default!('2d98d49cf712ca7dc6f4b23b9c5f5542385d8dbe') # taken from latest chromium-stable
   met? { dir.p.exists? }
   meet {
+    # uses system curl, which we remove later
+    shell 'apt-get install -y curl', sudo: true
     shell "mkdir -p #{dir}"
     cd dir do
-      shell 'git clone --depth=1 --branch=chromium-stable https://github.com/google/boringssl.git .'
-      shell "git checkout #{version}"
+      shell "curl -L -o boringssl.tar.gz https://boringssl.googlesource.com/boringssl/+archive/#{version}.tar.gz"
+      shell 'tar xzf boringssl.tar.gz -C ./'
+      shell 'rm boringssl.tar.gz'
     end
+  }
+  after {
+    shell 'apt-get remove -y curl', sudo: true
   }
 end
 

--- a/curl.rb
+++ b/curl.rb
@@ -1,19 +1,21 @@
 dep 'curl', :version do
   version.default!('7.61.1')
 
-  requires 'personal:git', 'lib.boringssl', 'lib.nghttp2'
+  requires 'lib.boringssl', 'lib.nghttp2'
   requires 'autoconf.bin', 'make.bin'
   on :debian do
     requires 'libtoolize.bin'
   end
 
-  met? { shell? "curl --version | grep #{version}" }
+  met? { shell? "curl --version | grep -E '^curl #{version}'" }
   meet {
     cd '/tmp' do
-      shell 'rm -rf curl'
-      shell 'git clone https://github.com/curl/curl.git'
-      cd 'curl' do
-        shell "git checkout curl-#{version.to_s.gsub('.', '_')}"
+      # uses system curl, which we remove later
+      shell 'apt-get install -y curl', sudo: true
+      shell "curl -L -o curl.tar.gz https://github.com/curl/curl/releases/download/curl-#{version.to_s.gsub('.', '_')}/curl-#{version}.tar.gz"
+      shell 'tar xzf curl.tar.gz'
+
+      cd "curl-#{version}" do
         shell './buildconf'
 
         on :debian do
@@ -44,7 +46,7 @@ dep 'curl', :version do
     end
   }
   after do
-    shell 'rm -rf /tmp/curl'
+    shell 'rm -rf /tmp/curl*'
     on :debian do
       shell 'apt-get remove -y curl', sudo: true
     end


### PR DESCRIPTION
Build directly from source tarball to remove the dependency on git,
which results in a circular dependency.