### PR TITLE
Fix up backports versions

### DIFF
--- a/debian_backports.rb
+++ b/debian_backports.rb
@@ -7,3 +7,10 @@ dep 'debian-backports'  do
     shell 'apt-get update', sudo: true
   }
 end
+
+meta :backports do
+  def apt_install(package, version = nil)
+    package_str = version.nil? ? package : "#{package}=#{version}"
+    shell "apt-get -y -t stretch-backports install #{package_str}", sudo: true
+  end
+end

--- a/git.rb
+++ b/git.rb
@@ -4,7 +4,7 @@ dep 'git' do
   end
 
   on :debian do
-    requires 'personal:git.debian.apt'
+    requires 'personal:git.debian.backports'
   end
 end
 
@@ -14,9 +14,9 @@ dep 'git.osx.src', :version do
   source "https://github.com/git/git/archive/v#{version}.zip"
 end
 
-dep 'git.debian.apt', :version do
-  version.default!('1:2.20.1-1~bpo9+1')
+dep 'git.debian.backports', :version do
+  version.default!('2.20.1')
   requires 'debian-backports'
-  met? { apt_installed? 'git', version }
-  meet { apt_install 'git', version, 'stretch-backports' }
+  met? { in_path? "git >= #{version}" }
+  meet { apt_install 'git' }
 end

--- a/tmux.rb
+++ b/tmux.rb
@@ -1,7 +1,7 @@
-dep 'tmux.debian.apt', :version do
+dep 'tmux.debian.backports', :version do
   requires 'debian-backports'
-  met? { apt_installed? 'tmux', version }
-  meet { apt_install 'tmux', version, 'stretch-backports' }
+  met? { in_path? "tmux >= #{version}" }
+  meet { apt_install 'tmux' }
 end
 
 dep 'tmux.osx', :version do
@@ -33,7 +33,7 @@ end
 
 dep 'tmux' do
   on :debian do
-    requires 'tmux.debian.apt'.with('2.8-2~bpo9+1')
+    requires 'tmux.debian.backports'.with('2.8')
   end
 
   on :osx do


### PR DESCRIPTION
Debian versions included in the distro can move around, which makes the
build non-hermetic (i.e. the build can fail when the versions in
backports change).

Don't pin to apt-installed versions.