### PR TITLE
Update curl and libnghttp2

### DIFF
--- a/curl.rb
+++ b/curl.rb
@@ -1,5 +1,5 @@
 dep 'curl', :version do
-  version.default!('7.64.0')
+  version.default!('7.64.1')
 
   requires 'lib.boringssl', 'lib.nghttp2'
   requires 'autoconf.bin', 'make.bin'

--- a/nghttp2.rb
+++ b/nghttp2.rb
@@ -5,7 +5,7 @@ meta :nghttp2 do
 end
 
 dep 'source.nghttp2', :version do
-  version.default!('1.37.0')
+  version.default!('1.38.0')
   met? { dir.p.exists? }
   meet {
     cd dir, create: true do


### PR DESCRIPTION
Update curl to 7.64.1.

Update libnghttp2 to 1.38.0.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>