### PR TITLE
Various fixes

### DIFF
--- a/java.rb
+++ b/java.rb
@@ -1,5 +1,5 @@
 dep 'openjdk.latest.bash', :version do
-  version.default! 'openjdk@1.13.0-23'
+  version.default! 'openjdk@1.13.0'
   requires 'jabba', 'dotfiles'
   met? { login_shell "jabba ls | grep #{version}" }
   meet {

--- a/rust.rb
+++ b/rust.rb
@@ -23,7 +23,7 @@ dep 'rustup.rust', :version do
       arch = 'x86_64-unknown-linux-gnu'
     end
     on :osx do
-      arch = 'x86_64-apply-darwin'
+      arch = 'x86_64-apple-darwin'
     end
     url = "#{url_base}/#{arch}/rustup-init"
     cd '/tmp' do


### PR DESCRIPTION
Pin Java 13 to 1.13.0.

Fix typo in macOS rust-init URL.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>