### PR TITLE
Upgrade tmux; Fix Helm

### DIFF
--- a/helm.rb
+++ b/helm.rb
@@ -26,7 +26,7 @@ dep 'helm', :version do
       on :osx do
         shell "tar xzf #{tarball} --strip-components 1 #{platform}/helm"
       end
-      shell "mv helm /usr/local/bin/helm"
+      shell "mv -f helm /usr/local/bin/helm"
     end
   }
   after {

--- a/tmux.rb
+++ b/tmux.rb
@@ -37,7 +37,7 @@ dep 'tmux' do
   end
 
   on :osx do
-    requires 'tmux.osx'.with('2.8')
+    requires 'tmux.osx'.with('2.9a')
   end
 
   requires 'tmux.dotfile'


### PR DESCRIPTION
Update tmux version on macOS to 2.9a.

Fix Helm install to forcefully move the binary into place.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>