### PR TITLE
Pin matryoshka version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,4 @@ jobs:
       - run:
           command: docker build -t dotfiles -f Dockerfile-debian .
       - run:
-          command: docker run --rm -it -v $(pwd):/deps dotfiles matryoshka -dir /deps -debug
+          command: docker run --rm -it -v $(pwd):/deps dotfiles matryoshka apply --dir /deps --debug

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -1,10 +1,12 @@
 FROM debian:stretch AS build
 
+ARG matryoshka_version=271c9d5
+
 WORKDIR /build
 
 RUN apt-get -y update && \
   apt-get install -y curl git && \
-  curl -L -o /tmp/go.tar.gz https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz && \
+  curl -L -o /tmp/go.tar.gz https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz && \
   tar xzf /tmp/go.tar.gz && \
   mv go /usr/local/ && \
   rm /tmp/go.tar.gz
@@ -12,7 +14,8 @@ RUN apt-get -y update && \
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN git clone https://github.com/nicktrav/matryoshka.git . && \
-  go build ./cmd/matryoshka/matryoshka.go
+  git checkout ${matryoshka_version} && \
+  go build -o matryoshka ./cmd/main.go
 
 FROM debian:stretch
 


### PR DESCRIPTION
Pin the version of the matryoshka binary to ensure that builds are
repeatable.

Update to the latest version of matryoshka.

Update Go version used in builds.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>