### PR TITLE
Update Rust version to 1.38.0

### DIFF
--- a/rust.dep
+++ b/rust.dep
@@ -1,6 +1,6 @@
 load('rustup.dep', 'rustup')
 
-VERSION = '1.37.0'
+VERSION = '1.38.0'
 
 toolchain = dep(
   name = 'rust-toolchain',


### PR DESCRIPTION
Signed-off-by: Nick Travers <n.e.travers@gmail.com>