### PR TITLE
Update boringssl, nghttp2 and curl

### DIFF
--- a/boringssl.dep
+++ b/boringssl.dep
@@ -1,6 +1,6 @@
 DIR = '~/Development/boringssl'
 GIT_REPO = 'https://boringssl.googlesource.com/boringssl'
-SHA = '8e8f250422663106d478f6927beefba289a95b37'
+SHA = '6f3e034fe58ce3bca3c1c32be6d603a6206c89af'
 
 load('dirs.dep', 'development_dir')
 load('git.dep', 'git')

--- a/curl.dep
+++ b/curl.dep
@@ -1,4 +1,4 @@
-VERSION = '7.65.1'
+VERSION = '7.66.0'
 VERSION_DASH = VERSION.replace('.', '_')
 
 load('autoconf.dep', 'autoconf')

--- a/nghttp2.dep
+++ b/nghttp2.dep
@@ -9,7 +9,7 @@ load('pkg-config.dep', 'pkg_config')
 
 DIR = '~/Development/nghttp2'
 GIT_REPO = 'https://github.com/nghttp2/nghttp2.git'
-SHA = '1.38.0'
+SHA = '1.39.1'
 
 # Source code
 


### PR DESCRIPTION
Update boringssl to latest chromium-stable.

Update nghttp2 to 1.39.1.

Update curl to 7.66.0.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>