### PR TITLE
Bump Java versions

### DIFF
--- a/java.dep
+++ b/java.dep
@@ -12,9 +12,9 @@ def java_version(version):
 java_versions = dep(
   name = 'java-versions',
   requires = [
-    java_version('openjdk@1.14.0-17'),
+    java_version('openjdk@1.14.0-20'),
     java_version('openjdk@1.11.0-2'),
-    java_version('adopt@1.8.0-222'),
+    java_version('adopt@1.8.0-232'),
   ],
 )
 


### PR DESCRIPTION
Update to:

- adopt@1.8.0-232
- openjdk@1.14.0-20

Signed-off-by: Nick Travers <n.e.travers@gmail.com>