### PR TITLE
Bump rustup version to 1.20.2

### DIFF
--- a/rustup.dep
+++ b/rustup.dep
@@ -1,7 +1,7 @@
 load('curl.dep', 'curl')
 load('dotfiles.dep', 'dotfiles')
 
-VERSION = '1.20.0'
+VERSION = '1.20.2'
 
 arch = 'apple-darwin' if os() == 'darwin' else 'unknown-linux-gnu'
 


### PR DESCRIPTION
Signed-off-by: Nick Travers <n.e.travers@gmail.com>