### PR TITLE
Update Go version to 1.13.5

### DIFF
--- a/go.dep
+++ b/go.dep
@@ -1,4 +1,4 @@
-VERSION = '1.13.4'
+VERSION = '1.13.5'
 PLATFORM = "{}-amd64".format(os())
 
 load('dotfiles.dep', 'dotfiles')


### PR DESCRIPTION
Signed-off-by: Nick Travers <n.e.travers@gmail.com>